### PR TITLE
Remove player death chat message

### DIFF
--- a/src/client/processor.rs
+++ b/src/client/processor.rs
@@ -98,7 +98,6 @@ impl<'a, I: InterfaceOut> InterfaceIn for SimpleInterfaceIn<'a, I> {
     fn on_death(&mut self) {
         self.actions.clear();
         self.out.respawn();
-        self.out.send_chat("I died... oof... well I guess I should respawn");
     }
 
     fn on_update_health(&mut self, health: f32, food: u8) {


### PR DESCRIPTION
Removes the chat message upon death, can be very annoying especially if the bot is supposed to die over and over silently